### PR TITLE
Potential fix for code scanning alert no. 1140: Bad HTML filtering regexp

### DIFF
--- a/vendor/bower/adminlte/dist/plugins/sparkline/jquery.sparkline.js
+++ b/vendor/bower/adminlte/dist/plugins/sparkline/jquery.sparkline.js
@@ -951,7 +951,7 @@
                     if (vals === undefined || vals === null) {
                         vals = $this.html();
                     }
-                    values = vals.replace(/(^\s*<!--)|(-->\s*$)|\s+/g, '').split(',');
+                    values = vals.replace(/(^\s*<!--)|(--!?>\s*$)|\s+/g, '').split(',');
                 } else {
                     values = userValues;
                 }


### PR DESCRIPTION
Potential fix for [https://github.com/bphndigitalservice/ildis/security/code-scanning/1140](https://github.com/bphndigitalservice/ildis/security/code-scanning/1140)

In general, to fix this kind of problem you must ensure that any regular expression intended to match HTML comment delimiters accounts for all variants that browsers accept, including the non‑standard but tolerated `--!>` variant. Since full HTML parsing with regex is not feasible, we only adjust the specific part the code cares about: recognizing and stripping a leading `<!--` and a trailing comment end marker that can be either `-->` or `--!>`.

In this file, the problematic regex is on line 954:

```js
values = vals.replace(/(^\s*<!--)|(-->\s*$)|\s+/g, '').split(',');
```

This expression does three things in one pass:  
1) remove a leading HTML comment start (`(^\s*<!--)`),  
2) remove a trailing HTML comment end (`(-->\s*$)`),  
3) collapse/remove whitespace (`\s+`).  

We only need to adjust the second alternation so it also matches `--!>`. The cleanest, behavior-preserving way is to replace `-->` with a small alternation `--!?>`, which matches either `-->` or `--!>`. That gives:

```js
values = vals.replace(/(^\s*<!--)|(--!?>\s*$)|\s+/g, '').split(',');
```

This keeps all existing behavior (strip `<!--` at the start, whitespace anywhere, a trailing `-->`), and additionally strips a trailing `--!>` when present. No new imports or helper methods are needed; we only update the regex in the existing line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
